### PR TITLE
Change mocap_msgs to mocap4r2_msgs

### DIFF
--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -2,8 +2,8 @@ repositories:
   mocap_msgs:
     type: git
     url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
-    version: master
+    version: rolling 
   mocap:
     type: git
     url: https://github.com/MOCAP4ROS2-Project/mocap.git
-    version: main
+    version: rolling

--- a/qualisys_driver/CMakeLists.txt
+++ b/qualisys_driver/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(mocap_msgs REQUIRED)
+find_package(mocap4r2_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
 
@@ -29,7 +29,7 @@ set(dependencies
   rclcpp_lifecycle
   tf2
   tf2_ros
-  mocap_msgs
+  mocap4r2_msgs
 )
 
 include_directories(

--- a/qualisys_driver/include/qualisys_driver/qualisys_driver.hpp
+++ b/qualisys_driver/include/qualisys_driver/qualisys_driver.hpp
@@ -39,10 +39,10 @@
 #include "lifecycle_msgs/srv/change_state.hpp"
 #include "lifecycle_msgs/srv/get_state.hpp"
 
-#include "mocap_msgs/msg/marker.hpp"
-#include "mocap_msgs/msg/markers.hpp"
-#include "mocap_msgs/msg/rigid_body.hpp"
-#include "mocap_msgs/msg/rigid_bodies.hpp"
+#include "mocap4r2_msgs/msg/marker.hpp"
+#include "mocap4r2_msgs/msg/markers.hpp"
+#include "mocap4r2_msgs/msg/rigid_body.hpp"
+#include "mocap4r2_msgs/msg/rigid_bodies.hpp"
 
 #include "std_msgs/msg/empty.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -98,8 +98,8 @@ private:
   int n_markers_;
   int n_unlabeled_markers_;
   std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> client_change_state_;
-  rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::Markers>::SharedPtr mocap_markers_pub_;
-  rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::RigidBodies>::SharedPtr
+  rclcpp_lifecycle::LifecyclePublisher<mocap4r2_msgs::msg::Markers>::SharedPtr mocap_markers_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<mocap4r2_msgs::msg::RigidBodies>::SharedPtr
     mocap_rigid_bodies_pub_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Empty>::SharedPtr update_pub_;
 };

--- a/qualisys_driver/package.xml
+++ b/qualisys_driver/package.xml
@@ -15,7 +15,7 @@
   <build_depend>tf2</build_depend>
   <build_depend>tf2_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>mocap_msgs</build_depend>
+  <build_depend>mocap4r2_msgs</build_depend>
   <build_depend>qualisys_cpp_sdk</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
@@ -25,7 +25,7 @@
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>mocap_msgs</exec_depend>
+  <exec_depend>mocap4r2_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/qualisys_driver/src/qualisys_driver.cpp
+++ b/qualisys_driver/src/qualisys_driver.cpp
@@ -130,7 +130,7 @@ void QualisysDriver::process_packet(CRTPacket * const packet)
   }
 
   if (mocap_markers_pub_->get_subscription_count() > 0) {
-    mocap_msgs::msg::Markers markers_msg;
+    mocap4r2_msgs::msg::Markers markers_msg;
     markers_msg.header.frame_id = "map";
     markers_msg.header.stamp = rclcpp::Clock().now();
     markers_msg.frame_number = frame_number;
@@ -138,7 +138,7 @@ void QualisysDriver::process_packet(CRTPacket * const packet)
     for (unsigned int i = 0; i < marker_count; ++i) {
       float x, y, z;
       packet->Get3DMarker((float)i, x, y, z);
-      mocap_msgs::msg::Marker this_marker;
+      mocap4r2_msgs::msg::Marker this_marker;
       this_marker.marker_index = i;
       this_marker.translation.x = x / 1000;
       this_marker.translation.y = y / 1000;
@@ -152,13 +152,13 @@ void QualisysDriver::process_packet(CRTPacket * const packet)
   }
 
   if (mocap_rigid_bodies_pub_->get_subscription_count() > 0) {
-    mocap_msgs::msg::RigidBodies msg_rb;
+    mocap4r2_msgs::msg::RigidBodies msg_rb;
     msg_rb.header.frame_id = "map";
     msg_rb.header.stamp = rclcpp::Clock().now();
     msg_rb.frame_number = frame_number;
 
     for (unsigned int i = 0; i < rb_count; i++) {
-      mocap_msgs::msg::RigidBody rb;
+      mocap4r2_msgs::msg::RigidBody rb;
 
       float x, y, z;
       float rot_matrix[9];
@@ -229,10 +229,10 @@ CallbackReturnT QualisysDriver::on_configure(const rclcpp_lifecycle::State &)
   client_change_state_ = this->create_client<lifecycle_msgs::srv::ChangeState>(
     "/qualisys_driver/change_state");
 
-  mocap_markers_pub_ = create_publisher<mocap_msgs::msg::Markers>(
+  mocap_markers_pub_ = create_publisher<mocap4r2_msgs::msg::Markers>(
     "/markers", 100);
 
-  mocap_rigid_bodies_pub_ = create_publisher<mocap_msgs::msg::RigidBodies>(
+  mocap_rigid_bodies_pub_ = create_publisher<mocap4r2_msgs::msg::RigidBodies>(
     "rigid_bodies", rclcpp::QoS(1000));
 
   update_pub_ = create_publisher<std_msgs::msg::Empty>(


### PR DESCRIPTION
Hi all,

A similar pull request from `mocap4r2_msgs` to `mocap_msgs` was merged previously. Thus, I am not certain if this pull request is relevant. But when we try to install the package, we encounter a couple of problems. First, there is no 'main' or 'master' branch anymore for the mocap4r2_msgs package, it is 'rolling'. Second, the name is `mocap4r2_msgs`, not `mocap_msgs`. So, this pull request changes `mocap_msgs` to `mocap4r2_msgs`.