### PR TITLE
Fix inconsistency in launch file and parameter file.

### DIFF
--- a/qualisys_driver/config/qualisys_driver_params.yaml
+++ b/qualisys_driver/config/qualisys_driver_params.yaml
@@ -1,7 +1,7 @@
-qualisys_driver_node:
+/qualisys_driver_node:
   ros__parameters:
-    host_name: "192.168.1.64"
-    host_port: 22222
+    host_name: "192.168.1.10"
+    port: 22222
     frame_count: 0
     last_frame_number: 0
     dropped_frame_count: 0

--- a/qualisys_driver/launch/qualisys.launch.py
+++ b/qualisys_driver/launch/qualisys.launch.py
@@ -46,7 +46,8 @@ def generate_launch_description():
         package='qualisys_driver',
         executable='qualisys_driver_main',
         output='screen',
-        parameters=[params_file_path],
+        arguments = ['--ros-args', '--params-file', str(params_file_path)],
+        # parameters=[params_file_path],
     )
 
     # Make the driver node take the 'configure' transition


### PR DESCRIPTION
Parameter file and launch file is often used as template and it currently contains inconsistencies. As @markusfossdal pointed out in downstream repo. He proposed changes and i'm just relaying those changes.

in the future, parameter reading can be done using parameter substitution as shown below, but, it is good enough for now.

```python
parameters=[launch.substitutions.LaunchConfiguration('param_file')],
```

see https://github.com/incebellipipo/mocap4ros2_qualisys/pull/1