### PR TITLE
Get the rigid body label to set as name

### DIFF
--- a/qualisys_driver/src/qualisys_driver.cpp
+++ b/qualisys_driver/src/qualisys_driver.cpp
@@ -166,7 +166,9 @@ void QualisysDriver::process_packet(CRTPacket * const packet)
       packet->Get6DOFBody(i, x, y, z, rot_matrix);
       Quaternion quaternion = matrixToQuaternion(rot_matrix);
 
-      rb.rigid_body_name = std::to_string(i);
+      const char* label = port_protocol_.Get6DOFBodyName(i);
+  
+      rb.rigid_body_name = label;
       rb.pose.position.x = x / 1000;
       rb.pose.position.y = y / 1000;
       rb.pose.position.z = z / 1000;


### PR DESCRIPTION
Currently the rigid body name is set as the index of detected body in array. It would be more useful to set this to the label assigned to the subject (in subject creation). This allows rigid bodies to be identified by label. Currently, the subject label is not accessible anywhere else so this change exposes it.